### PR TITLE
add Edit Form

### DIFF
--- a/lib/input_form_wdiget.dart
+++ b/lib/input_form_wdiget.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 class InputFormWidget extends StatefulWidget {
+  InputFormWidget(this.document); // コンストラクタ
+  final DocumentSnapshot document;
+
   @override
   State<StatefulWidget> createState() => MyInputFormState();
 }
@@ -19,6 +22,7 @@ class _FormData {
 class MyInputFormState extends State<InputFormWidget> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final _FormData _data = _FormData();
+  DocumentReference _mainReference;
 
   void _setLendOrRent(String value) {
     setState(() {
@@ -35,11 +39,25 @@ class MyInputFormState extends State<InputFormWidget> {
         lastDate: DateTime(_data.date.year + 2));
   }
 
+
+  @override
+  void initState() {
+    _mainReference = Firestore.instance.collection('memo-sample').document();
+    //引数で渡した編集対象のデータがなければ新規作成なので、データの読み込みを行わない
+    if (widget.document != null) {
+      if(_data.user == null && _data.stuff == null) {
+        _data.borrowOrLend = widget.document['borrowOrLend'];
+        _data.user = widget.document['user'];
+        _data.stuff = widget.document['stuff'];
+        _data.date = widget.document['date'].toDate();
+      }
+      _mainReference = Firestore.instance.collection('memo-sample').
+      document(widget.document.documentID);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    DocumentReference _mainReference;
-    _mainReference = Firestore.instance.collection('memo-sample').document();
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('貸し借り入力'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,7 +53,7 @@ class _MyList extends State<List> {
               context,
               MaterialPageRoute(
                   settings: const RouteSettings(name: "/new"),
-                  builder: (BuildContext context) => InputFormWidget()
+                  builder: (BuildContext context) => InputFormWidget(null)
               ),
             );
           }
@@ -77,7 +77,17 @@ class _MyList extends State<List> {
                   children: <Widget>[
                     FlatButton(
                         child: const Text("編集"),
-                        onPressed: () => print("編集ボタンを押しました")
+                        onPressed: () {
+                          print("編集ボタンを押しました");
+                          //編集ボタンの処理追加
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                settings: const RouteSettings(name: "/edit"),
+                                builder: (BuildContext context) => InputFormWidget(document)
+                            ),
+                          );
+                        }
                     ),
                   ],
                 )


### PR DESCRIPTION
# 編集画面の追加実装

- `InputFormWidget`に引数を追加
  - 引数に編集対象のデータ `FormDataクラス`があるかどうかで編集画面かどうかの判断をおこなう

- 参考文献だと`BuildWidget`ツリー配下で編集用データの読み込みを行っていたが、画面作成時の一度で十分な内容であるし、`SetState()`で`BuildWidget`が呼ばれる度に編集用データのチェックを行なうのがエコではないので `InitState()`のタイミングのみに修正した
