### PR TITLE
Add login

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -45,6 +45,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     buildTypes {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -9,6 +9,9 @@ PODS:
     - Firebase/Core
     - Firebase/Firestore (~> 6.0)
     - Flutter
+  - Firebase/Auth (6.5.0):
+    - Firebase/CoreOnly
+    - FirebaseAuth (~> 6.2.1)
   - Firebase/Core (6.5.0):
     - Firebase/CoreOnly
     - FirebaseAnalytics (= 6.0.4)
@@ -17,6 +20,10 @@ PODS:
   - Firebase/Firestore (6.5.0):
     - Firebase/CoreOnly
     - FirebaseFirestore (~> 1.4.2)
+  - firebase_auth (0.0.1):
+    - Firebase/Auth (~> 6.0)
+    - Firebase/Core
+    - Flutter
   - firebase_core (0.0.1):
     - Firebase/Core
     - Flutter
@@ -29,6 +36,12 @@ PODS:
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (~> 0.3)
+  - FirebaseAuth (6.2.1):
+    - FirebaseAuthInterop (~> 1.0)
+    - FirebaseCore (~> 6.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.2)
+    - GoogleUtilities/Environment (~> 6.2)
+    - GTMSessionFetcher/Core (~> 1.1)
   - FirebaseAuthInterop (1.0.0)
   - FirebaseCore (6.1.0):
     - GoogleUtilities/Environment (~> 6.0)
@@ -53,6 +66,8 @@ PODS:
     - GoogleUtilities/Environment (~> 6.0)
     - GoogleUtilities/UserDefaults (~> 6.0)
   - Flutter (1.0.0)
+  - fluttertoast (0.0.2):
+    - Flutter
   - GoogleAppMeasurement (6.0.4):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
@@ -93,6 +108,7 @@ PODS:
     - gRPC-Core/Interface (= 1.21.0)
     - nanopb (~> 0.3)
   - gRPC-Core/Interface (1.21.0)
+  - GTMSessionFetcher/Core (1.2.2)
   - leveldb-library (1.20)
   - nanopb (0.3.901):
     - nanopb/decode (= 0.3.901)
@@ -103,14 +119,17 @@ PODS:
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
+  - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `.symlinks/flutter/ios`)
+  - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - BoringSSL-GRPC
     - Firebase
     - FirebaseAnalytics
+    - FirebaseAuth
     - FirebaseAuthInterop
     - FirebaseCore
     - FirebaseFirestore
@@ -119,6 +138,7 @@ SPEC REPOS:
     - GoogleUtilities
     - "gRPC-C++"
     - gRPC-Core
+    - GTMSessionFetcher
     - leveldb-library
     - nanopb
     - Protobuf
@@ -126,26 +146,34 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   cloud_firestore:
     :path: ".symlinks/plugins/cloud_firestore/ios"
+  firebase_auth:
+    :path: ".symlinks/plugins/firebase_auth/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: ".symlinks/flutter/ios"
+  fluttertoast:
+    :path: ".symlinks/plugins/fluttertoast/ios"
 
 SPEC CHECKSUMS:
   BoringSSL-GRPC: db8764df3204ccea016e1c8dd15d9a9ad63ff318
   cloud_firestore: 5698a9bd01b94fd31e7b7b56d8fe1665f4fb43cb
   Firebase: dedc9e48ea3f3649ad5f6b982f8a0c73508a14b5
+  firebase_auth: a40261b555156aefc809c353488f9b7ca94005f9
   firebase_core: bae884ab4513092d80d01406455054a5af5482dd
   FirebaseAnalytics: 3fb375bc9d13779add4039716f868d233a473fad
+  FirebaseAuth: a06ad63e9bf4c86165b54cceb1c14d4f4c38d419
   FirebaseAuthInterop: 0ffa57668be100582bb7643d4fcb7615496c41fc
   FirebaseCore: aecf02fb2274ec361b9bebeac112f5daa18273bd
   FirebaseFirestore: 41a035642eb017fc7206318985501626993840bd
   FirebaseInstanceID: 662b8108a09fe9ed01aafdedba100fde8536b0f6
   Flutter: 58dd7d1b27887414a370fcccb9e645c08ffd7a6a
+  fluttertoast: b644586ef3b16f67fae9a1f8754cef6b2d6b634b
   GoogleAppMeasurement: 183bd916af7f80deb67c01888368f1108d641832
   GoogleUtilities: d2b0e277a95962e09bb27f5cd42f5f0b6a506c7d
   "gRPC-C++": 9dfe7b44821e7b3e44aacad2af29d2c21f7cde83
   gRPC-Core: c9aef9a261a1247e881b18059b84d597293c9947
+  GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
   leveldb-library: 08cba283675b7ed2d99629a4bc5fd052cd2bb6a5
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
   Protobuf: 1097ca58584c8d9be81bfbf2c5ff5975648dd87a

--- a/lib/input_form_wdiget.dart
+++ b/lib/input_form_wdiget.dart
@@ -1,10 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 class InputFormWidget extends StatefulWidget {
-  InputFormWidget(this.document); // コンストラクタ
+  InputFormWidget(this.document, this.firebaseUser); // コンストラクタ
   final DocumentSnapshot document;
+  final FirebaseUser firebaseUser;
 
   @override
   State<StatefulWidget> createState() => MyInputFormState();
@@ -22,9 +24,6 @@ class _FormData {
 class MyInputFormState extends State<InputFormWidget> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final _FormData _data = _FormData();
-  DocumentReference _mainReference;
-  bool deleteFlg = false;
-
   void _setLendOrRent(String value) {
     setState(() {
       _data.borrowOrLend = value;
@@ -41,10 +40,17 @@ class MyInputFormState extends State<InputFormWidget> {
   }
 
   @override
-  void initState() {
-    _mainReference = Firestore.instance.collection('memo-sample').document();
+  Widget build(BuildContext context) {
+    DocumentReference _mainReference;
+    _mainReference = Firestore.instance
+        .collection('users')
+        .document(widget.firebaseUser.uid)
+        .collection("transaction") // テーブル名
+        .document();
     //引数で渡した編集対象のデータがなければ新規作成なので、データの読み込みを行わない
+    bool deleteFlg = false;
     if (widget.document != null) {
+      //引数で渡したデータがあるかどうか
       if (_data.user == null && _data.stuff == null) {
         _data.borrowOrLend = widget.document['borrowOrLend'];
         _data.user = widget.document['user'];
@@ -52,15 +58,14 @@ class MyInputFormState extends State<InputFormWidget> {
         _data.date = widget.document['date'].toDate();
       }
       _mainReference = Firestore.instance
-          .collection('memo-sample')
+          .collection('users')
+          .document(widget.firebaseUser.uid)
+          .collection("transaction") // テーブル名
           .document(widget.document.documentID);
       // 編集画面なので削除ボタン活性化フラグを立てる
       deleteFlg = true;
     }
-  }
 
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('貸し借り入力'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
       home: SplashScreen(),
       routes: <String, WidgetBuilder>{
         '/list': (_) => List(),
-        '/splash_screen': (BuildContext context) =>  SplashScreen(),
+        '/splash_screen': (BuildContext context) => SplashScreen(),
       },
     );
   }
@@ -30,76 +30,217 @@ class List extends StatefulWidget {
 }
 
 class _MyList extends State<List> {
-
   Widget build(BuildContext context) {
+    final Map<String, dynamic> args = ModalRoute.of(context).settings.arguments;
+    FirebaseUser _firebaseUser = args["firebaseUser"];
+    final FirebaseAuth _auth = args["auth"];
     return Scaffold(
       appBar: AppBar(
         title: const Text("リスト画面"),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.exit_to_app),
+            onPressed: () {
+              print("login");
+              showBasicDialog(context, _firebaseUser, _auth);
+            },
+          )
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(8.0),
         child: StreamBuilder<QuerySnapshot>(
-            stream: Firestore.instance.collection('memo-sample').snapshots(),
-            builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot){
-              if (!snapshot.hasData) return const Text('Loading...');
-              return ListView.builder(
-                // 'documents'がレコード単位のデータかも
-                itemCount: snapshot.data.documents.length,
-                padding: const EdgeInsets.only(top: 10.0),
-                itemBuilder: (context, index) => _buildListItem(context, snapshot.data.documents[index]),
-              );
-            }
+          stream: Firestore.instance.collection('memo-sample').snapshots(),
+          builder:
+              (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
+            if (!snapshot.hasData) return const Text('Loading...');
+            return ListView.builder(
+              // 'documents'がレコード単位のデータかも
+              itemCount: snapshot.data.documents.length,
+              padding: const EdgeInsets.only(top: 10.0),
+              itemBuilder: (context, index) =>
+                  _buildListItem(context, snapshot.data.documents[index]),
+            );
+          },
         ),
       ),
       floatingActionButton: FloatingActionButton(
-          child: const Icon(Icons.add),
-          onPressed: () {
-            print("新規作成ボタンを押しました");
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                  settings: const RouteSettings(name: "/new"),
-                  builder: (BuildContext context) => InputFormWidget(null)
-              ),
-            );
-          }
+        child: const Icon(Icons.add),
+        onPressed: () {
+          print("新規作成ボタンを押しました");
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+                settings: const RouteSettings(name: "/new"),
+                builder: (BuildContext context) => InputFormWidget(null)),
+          );
+        },
       ),
     );
   }
 
+  /// ログインと新規登録
+  void showBasicDialog(
+      BuildContext context, FirebaseUser firebaseUser, FirebaseAuth _auth) {
+    final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+    String email, password;
+    if (firebaseUser.isAnonymous) {
+      showDialog(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          title: Text("ログイン/登録ダイアログ"),
+          content: Form(
+            key: _formKey,
+            child: Column(
+              children: <Widget>[
+                TextFormField(
+                  decoration: const InputDecoration(
+                    icon: const Icon(Icons.mail),
+                    labelText: 'Email',
+                  ),
+                  onSaved: (String value) {
+                    email = value;
+                  },
+                  validator: (value) {
+                    if (value.isEmpty) {
+                      return 'Emailは必須入力項目です';
+                    }
+                  },
+                ),
+                TextFormField(
+                  obscureText: true,
+                  decoration: const InputDecoration(
+                    icon: const Icon(Icons.vpn_key),
+                    labelText: 'Password',
+                  ),
+                  onSaved: (String value) {
+                    password = value;
+                  },
+                  validator: (value) {
+                    if (value.isEmpty) {
+                      return 'Passwordは必須入力項目です';
+                    }
+                    if (value.length < 6) {
+                      return 'Passwordは6桁以上です';
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+          // ボタンの配置
+          actions: <Widget>[
+            FlatButton(
+              child: const Text('キャンセル'),
+              onPressed: () {
+                Navigator.pop(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('登録'),
+              onPressed: () {
+                if (_formKey.currentState.validate()) {
+                  _formKey.currentState.save();
+                  _createUser(context, email, password, _auth);
+                }
+              },
+            ),
+            FlatButton(
+              child: const Text('ログイン'),
+              onPressed: () {
+                if (_formKey.currentState.validate()) {
+                  _formKey.currentState.save();
+                  _signIn(context, email, password, _auth);
+                }
+              },
+            ),
+          ],
+        ),
+      );
+    } else {
+      showDialog(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          title: const Text("確認ダイアログ"),
+          content: Text(firebaseUser.email + " でログインしています。"),
+          actions: <Widget>[
+            FlatButton(
+              child: const Text('キャンセル'),
+              onPressed: () {
+                Navigator.pop(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('ログアウト'),
+              onPressed: () {
+                _auth.signOut();
+                Navigator.pushNamedAndRemoveUntil(
+                    context, "/splash_screen", (_) => false);
+              },
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  void _signIn(BuildContext context, String email, String password,
+      FirebaseAuth _auth) async {
+    try {
+      await _auth.signInWithEmailAndPassword(email: email, password: password);
+      Navigator.pushNamedAndRemoveUntil(
+          context, "/splash_screen", (_) => false);
+    } catch (e) {
+      Fluttertoast.showToast(msg: "Firebaseのログインに失敗しました。");
+    }
+  }
+
+  void _createUser(BuildContext context, String email, String password,
+      FirebaseAuth _auth) async {
+    try {
+      await _auth.createUserWithEmailAndPassword(
+          email: email, password: password);
+      Navigator.pushNamedAndRemoveUntil(
+          context, "/splash_screen", (_) => false);
+    } catch (e) {
+      Fluttertoast.showToast(msg: "Firebaseの登録に失敗しました。");
+    }
+  }
+
   /// リストアイテムWidget(一個一個のリスト単位のWidget)
-  Widget _buildListItem(BuildContext context, DocumentSnapshot document){
+  Widget _buildListItem(BuildContext context, DocumentSnapshot document) {
     return Card(
-      child: Column(
-          mainAxisSize: MainAxisSize.min,
+      child: Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
+        ListTile(
+          leading: const Icon(Icons.android),
+          title: Text("【 " +
+              (document['borrowOrLend'] == "lend" ? "貸" : "借") +
+              " 】" +
+              document['stuff']),
+          subtitle: Text('期限 ： ' +
+              document['date'].toDate().toString().substring(0, 10) +
+              "\n相手 ： " +
+              document['user']),
+        ),
+        ButtonTheme.bar(
+            child: ButtonBar(
           children: <Widget>[
-            ListTile(
-              leading: const Icon(Icons.android),
-              title: Text("【 " + (document['borrowOrLend'] == "lend"?"貸": "借") +" 】"+ document['stuff']),
-              subtitle: Text('期限 ： ' + document['date'].toDate().toString().substring(0,10) + "\n相手 ： " + document['user']),
-            ),
-            ButtonTheme.bar(
-                child: ButtonBar(
-                  children: <Widget>[
-                    FlatButton(
-                        child: const Text("編集"),
-                        onPressed: () {
-                          print("編集ボタンを押しました");
-                          //編集ボタンの処理追加
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                settings: const RouteSettings(name: "/edit"),
-                                builder: (BuildContext context) => InputFormWidget(document)
-                            ),
-                          );
-                        }
-                    ),
-                  ],
-                )
-            ),
-          ]
-      ),
+            FlatButton(
+                child: const Text("編集"),
+                onPressed: () {
+                  print("編集ボタンを押しました");
+                  //編集ボタンの処理追加
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        settings: const RouteSettings(name: "/edit"),
+                        builder: (BuildContext context) =>
+                            InputFormWidget(document)),
+                  );
+                }),
+          ],
+        )),
+      ]),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,7 +50,12 @@ class _MyList extends State<List> {
       body: Padding(
         padding: const EdgeInsets.all(8.0),
         child: StreamBuilder<QuerySnapshot>(
-          stream: Firestore.instance.collection('memo-sample').snapshots(),
+          // ログインしたユーザーIDからドキュメントを取得しにいく
+          stream: Firestore.instance
+              .collection('users')
+              .document(_firebaseUser.uid)
+              .collection("transaction")
+              .snapshots(),
           builder:
               (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
             if (!snapshot.hasData) return const Text('Loading...');
@@ -58,8 +63,8 @@ class _MyList extends State<List> {
               // 'documents'がレコード単位のデータかも
               itemCount: snapshot.data.documents.length,
               padding: const EdgeInsets.only(top: 10.0),
-              itemBuilder: (context, index) =>
-                  _buildListItem(context, snapshot.data.documents[index]),
+              itemBuilder: (context, index) => _buildListItem(
+                  context, snapshot.data.documents[index], _firebaseUser),
             );
           },
         ),
@@ -71,8 +76,10 @@ class _MyList extends State<List> {
           Navigator.push(
             context,
             MaterialPageRoute(
-                settings: const RouteSettings(name: "/new"),
-                builder: (BuildContext context) => InputFormWidget(null)),
+              settings: const RouteSettings(name: "/new"),
+              builder: (BuildContext context) =>
+                  InputFormWidget(null, _firebaseUser),
+            ),
           );
         },
       ),
@@ -208,7 +215,8 @@ class _MyList extends State<List> {
   }
 
   /// リストアイテムWidget(一個一個のリスト単位のWidget)
-  Widget _buildListItem(BuildContext context, DocumentSnapshot document) {
+  Widget _buildListItem(BuildContext context, DocumentSnapshot document,
+      FirebaseUser firebaseUser) {
     return Card(
       child: Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
         ListTile(
@@ -233,9 +241,10 @@ class _MyList extends State<List> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                        settings: const RouteSettings(name: "/edit"),
-                        builder: (BuildContext context) =>
-                            InputFormWidget(document)),
+                      settings: const RouteSettings(name: "/edit"),
+                      builder: (BuildContext context) =>
+                          InputFormWidget(document, firebaseUser),
+                    ),
                   );
                 }),
           ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_firebase_sample/splash_screen.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'input_form_wdiget.dart';
 
 void main() => runApp(MyApp());
@@ -13,7 +15,11 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: List(),
+      home: SplashScreen(),
+      routes: <String, WidgetBuilder>{
+        '/list': (_) => List(),
+        '/splash_screen': (BuildContext context) =>  SplashScreen(),
+      },
     );
   }
 }

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -25,7 +25,14 @@ void _getUser(BuildContext context) async {
       await _auth.signInAnonymously();
       firebaseUser = await _auth.currentUser();
     }
-    Navigator.pushReplacementNamed(context, "/list");
+    Navigator.pushReplacementNamed(
+      context,
+      "/list",
+      arguments: {
+        "firebaseUser": firebaseUser,
+        "auth": _auth,
+      },
+    );
   } catch (e) {
     Fluttertoast.showToast(msg: "Firebaseとの接続に失敗しました。");
   }

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -34,6 +34,7 @@ void _getUser(BuildContext context) async {
       },
     );
   } catch (e) {
+    print("FirebaseAuth : $e");
     Fluttertoast.showToast(msg: "Firebaseとの接続に失敗しました。");
   }
 }

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -1,0 +1,32 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+class SplashScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    _getUser(context);
+    return Scaffold(
+      body: Center(
+        child: const Text("スプラッシュ画面"),
+      ),
+    );
+  }
+}
+
+void _getUser(BuildContext context) async {
+  FirebaseUser firebaseUser;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  try {
+    firebaseUser = await _auth.currentUser();
+    if (firebaseUser == null) {
+      await _auth.signInAnonymously();
+      firebaseUser = await _auth.currentUser();
+    }
+    Navigator.pushReplacementNamed(context, "/list");
+  } catch (e) {
+    Fluttertoast.showToast(msg: "Firebaseとの接続に失敗しました。");
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
   cloud_firestore: ^0.12.7
+  firebase_auth: ^0.14.0
+  fluttertoast: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# ログイン機能の追加

- スプラッシュ画面を新規作成
  - `FirebaseAuth`の情報を取得、現在ログイン中かどうかを判断する
  - 未ログインなら匿名ユーザーとして扱う
  - ログイン済みならユーザー情報をメイン画面に引き渡す
- サインアップ・サインインフォームの作成

![firebase](https://user-images.githubusercontent.com/31891340/62819602-5956f080-bb92-11e9-9ec7-743b291e2434.gif)

