### PR TITLE
違うユーザーでログインする機能

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_facebook_login/flutter_facebook_login.dart';
 import 'package:flutter_firebase_sample/splash_screen.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'input_form_wdiget.dart';
@@ -181,6 +182,7 @@ class _MyList extends State<List> {
               child: const Text('ログアウト'),
               onPressed: () {
                 _auth.signOut();
+                FacebookLogin().logOut();
                 Navigator.pushNamedAndRemoveUntil(
                     context, "/splash_screen", (_) => false);
               },

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -29,7 +29,12 @@ void initiateFacebookLogin(BuildContext context) async {
   switch (facebookLoginResult.status) {
     case FacebookLoginStatus.error:
       print("Error");
-      Fluttertoast.showToast(msg: "Facebookでのログインに失敗しました。");
+      if (facebookLoginResult.errorMessage == "User logged in as different Facebook user.") {
+        facebookLogin.logOut();
+        Fluttertoast.showToast(msg: "ログインに失敗しました。もう一度お試しください。");
+      } else {
+        Fluttertoast.showToast(msg: "Facebookでのログインに失敗しました。");
+      }
       break;
     case FacebookLoginStatus.cancelledByUser:
       print("CancelledByUser");


### PR DESCRIPTION
正確には前のユーザーでログアウトしていないと、違うユーザーでログイン出来ないでいた。

Facebook認証トークンが残っている場合は一度ログアウトを試行して、もう一度ログインを促すようにした。